### PR TITLE
Update submodule URLs to HTTPs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git@github.com:psychoinformatics-de/studyforrest-data-eyemovementlabels.git
 [submodule "remodnav"]
 	path = remodnav
-	url = git@github.com:psychoinformatics-de/remodnav.git
+	url = https://github.com/psychoinformatics-de/remodnav.git
 [submodule "data/raw_eyegaze"]
 	path = data/raw_eyegaze
 	url = https://github.com/psychoinformatics-de/studyforrest-data-phase2.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "data/studyforrest-data-eyemovementlabels"]
 	path = data/studyforrest-data-eyemovementlabels
-	url = git@github.com:psychoinformatics-de/studyforrest-data-eyemovementlabels.git
+	url = https://github.com/psychoinformatics-de/studyforrest-data-eyemovementlabels.git
 [submodule "remodnav"]
 	path = remodnav
 	url = https://github.com/psychoinformatics-de/remodnav.git


### PR DESCRIPTION
This is related to a problem @jsheunis encountered when transforming tutorials into Binder-hosted Jupyter Notebooks (https://github.com/datalad-handbook/datalad-tutorial-binder/issues/1): Anyone without an SSH setup won't be able to retrieve the subdatasets, as they had been configured with SSH urls. This PR switches them to HTTPS. @mih, can you give me quick thumbs up?