### PR TITLE
Add patch for compatibility with newer numpy versions

### DIFF
--- a/code/mk_figuresnstats.py
+++ b/code/mk_figuresnstats.py
@@ -12,6 +12,11 @@ import sys
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 import numpy as np
+try:
+    np.bool
+except AttributeError:
+    # monkey patch to be able to use with older seaborn version
+    np.bool = np.bool_
 import pandas as pd
 from scipy.signal import (
     butter,


### PR DESCRIPTION
We do not need it directly, but the old seaborn we need to use for reproducibility will not work with recent numpy versions anymore, because they changed the API.

This patch patches numpy to restore the old API aspect that seaborn 0.10 needs.