### PR TITLE
Make DataLad optional

### DIFF
--- a/code/mk_figuresnstats.py
+++ b/code/mk_figuresnstats.py
@@ -22,7 +22,15 @@ from scipy.spatial import distance
 import seaborn as sns
 from sklearn.metrics import cohen_kappa_score
 
-from datalad.api import get as datalad_get
+try:
+    from datalad.api import get as datalad_get
+except ImportError:
+    def datalad_get(*args, **kwargs):
+        print('Skipping datalad-get operation, DataLad is not available. '
+              'Ensure data availability by other means. Call was: '
+              f"get({', '.join(repr(a) for a in args)}, {', '.join('{}={}'.format(k, v) for k, v in kwargs.items())})"
+        )
+
 
 from remodnav import (
     EyegazeClassifier,


### PR DESCRIPTION
This change replaces `datalad_get()` with a noop function, whenever datalad is not available.

This change enables other means of provisioning data, and/or running the analysis code in environments where datalad is not available.

When datalad is not around, the replacement function produces a message that reports the data file it would have provisioned.