### PR TITLE
Add docker container recipe and makefile for reproducing the analysis

### DIFF
--- a/Docker-Makefile
+++ b/Docker-Makefile
@@ -1,0 +1,23 @@
+# use `chronic` to make output look neater, if available
+CHRONIC=$(shell which chronic || echo '' )
+
+PYTHON=python3
+
+
+all: main.pdf
+
+main.pdf: main.tex results_def.tex references.bib 
+	$(MAKE) main.pdf
+
+# the stats-script outputs all scores and figures
+results_def.tex: code/mk_figuresnstats.py
+	@echo "# Ensure REMODNAV installation"
+	@$(CHRONIC) $(PYTHON) -m pip install --break-system-packages -e remodnav
+	@rm -f $@
+	@REMODNAV_RESULTS=$@ $(PYTHON) code/mk_figuresnstats.py -s -f -r -m
+
+clean:
+	$(MAKE) clean
+	rm -rf .cache .config .local .texlive*
+
+.PHONY: clean

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq -y --allow-releaseinfo-change && \
+# basic tooling we need for building/installing
+apt-get install -q --no-install-recommends -y make && \
+# for compiling custom python package installs
+apt-get install -q --no-install-recommends -y build-essential python3-dev && \
+# any python package we do NOT need to compile
+apt-get install -q --no-install-recommends -y python3-virtualenv python3-wheel python3-scipy python3-sklearn python3-statsmodels python3-pyparsing python3-pil python3-pip && \
+# now python packages that we need specific versions of
+# we need the following packages pinned
+# - matplotlib for a particular SVG file content (structure)
+# - pandas as the last per v2 release for an API incompatibility that with 2x
+# - seaborn for minor changes in figure composition in later versions
+# - and numpy...the version does not matter, but it has to be different from
+#   the Debian-provided one, such that pip will compile it
+#   full and long story at
+#   https://github.com/psychoinformatics-de/paper-remodnav/issues/20
+python3 -m pip install --break-system-packages numpy==1.24.3 pandas==1.5.3 seaborn==0.10.1 matplotlib==3.4.3 && \
+# now the pieces we need to build the PDF
+apt-get install -q --no-install-recommends -y inkscape latexmk texlive-latex-extra && \
+# trim the image size
+rm -rf /root/.local /root/.cache /var/lib/apt/lists/deb.debian.org* ; \
+apt-get purge -y build-essential ; \
+apt-get autoremove -y ; \
+apt-get clean


### PR DESCRIPTION
Recently the original virtualenv-baseed approach started to fall apart, because mutual incompatibilities between the dependencies (some pinned at old versions) increased.

This changeset provides a container recipe to generate a modern (or most modern, given todays possibilities) environment to still reproduce the analysis.

The container image can be built with

```
docker build -t remodnav:latest container
```

And the manuscript can be generated with

```
docker run -v $PWD:/tmp -w /tmp --rm --interactive --tty \
  -u $(id -u):$(id -g) -e HOME=/tmp \
  remodnav:latest \
   make -f Docker-Makefile main.pdf
```

This does not reproduce everything exactly. There is a small (I'd say insignificant) change in one panel of a Fig 4. The full backstory and analysis of the cause is in
https://github.com/psychoinformatics-de/paper-remodnav/issues/20. However, besides that **all** reported statistical scores and performance measures reported in the paper remain identical.

Not that execution inside the container requires all inputs to be provisioned before. Here is the specification

```
remodnav/remodnav/tests/data/anderson_etal
remodnav/remodnav/tests/data/studyforrest
data/studyforrest-data-eyemovementlabels/*/*.tsv
data/raw_eyegaze/sub-*/ses-movie/func/*_recording-eyegaze_physio.tsv.gz
data/raw_eyegaze/sub-*/beh/*_recording-eyegaze_physio.tsv.gz
```

This will again be automated in a future changeset, based on a container-run provenance record.